### PR TITLE
add ExpenseReminders WIP

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddExpenseReminderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddExpenseReminderCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.ExpenseReminder;
+
+
+
+/**
+ * Adds a person to the address book.
+ */
+public class AddExpenseReminderCommand extends Command {
+
+    public static final String COMMAND_WORD = "addExpenseReminder";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an Expense Reminder to reminders list. "
+            + "Parameters: "
+            + PREFIX_DESC + "REMINDER_MESSAGE"
+            + PREFIX_AMOUNT + "QUOTA "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_DESC + "fat "
+            + PREFIX_AMOUNT + "5.50 "
+            + PREFIX_TAG + "food "
+            + PREFIX_TAG + "mala";
+
+    public static final String MESSAGE_SUCCESS = "New ExpenseReminder added: %1$s";
+
+    private final ExpenseReminder toAdd;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person}
+     */
+    public AddExpenseReminderCommand(ExpenseReminder reminder) {
+        requireNonNull(reminder);
+        toAdd = reminder;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.addExpenseReminder(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddExpenseReminderCommand // instanceof handles nulls
+                && toAdd.equals(((AddExpenseReminderCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddExpenseReminderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddExpenseReminderCommandParser.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddExpenseReminderCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Amount;
+import seedu.address.model.person.Description;
+import seedu.address.model.person.ExpenseContainsTagPredicate;
+import seedu.address.model.person.ExpenseReminder;
+import seedu.address.model.person.ExpenseTracker;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddExpenseReminderCommandParser implements Parser<AddExpenseReminderCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddExpenseReminderCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DESC, PREFIX_AMOUNT, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_DESC, PREFIX_AMOUNT, PREFIX_TAG)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddExpenseReminderCommand.MESSAGE_USAGE));
+        }
+
+        Description desc = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESC).get());
+        Amount amt = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        ExpenseContainsTagPredicate predicate = new ExpenseContainsTagPredicate(tagList);
+        ExpenseTracker tracker = new ExpenseTracker(predicate);
+        ExpenseReminder newreminder = new ExpenseReminder(desc.toString(), (long) amt.value, tracker);
+
+        return new AddExpenseReminderCommand(newreminder);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddExpenseReminderCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -91,6 +92,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddExpenseReminderCommand.COMMAND_WORD:
+            return new AddExpenseReminderCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,10 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.Entry;
 import seedu.address.model.person.Expense;
 import seedu.address.model.person.ExpenseList;
+import seedu.address.model.person.ExpenseReminder;
+import seedu.address.model.person.ExpenseReminderList;
+import seedu.address.model.person.ExpenseTracker;
+import seedu.address.model.person.ExpenseTrackerList;
 import seedu.address.model.person.Income;
 import seedu.address.model.person.IncomeList;
 import seedu.address.model.person.UniqueEntryList;
@@ -24,7 +28,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     private final ExpenseList expenses;
     private final IncomeList incomes;
     private final WishList wishes;
-
+    private final ExpenseReminderList expenseReminders;
+    private final ExpenseTrackerList expenseTrackers;
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
@@ -37,6 +42,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         expenses = new ExpenseList();
         incomes = new IncomeList();
         wishes = new WishList();
+        expenseReminders = new ExpenseReminderList();
+        expenseTrackers = new ExpenseTrackerList();
     }
 
     public AddressBook() {}
@@ -65,6 +72,12 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void setWishes(List<Wish> wishes) { this.wishes.setEntries(wishes); }
 
+    public void setExpenseReminders(List<ExpenseReminder> expenseReminders) {
+        this.expenseReminders.setEntries(expenseReminders);
+    }
+
+    public void setExpenseTrackers(List<ExpenseTracker> trackers) { this.expenseTrackers.setEntries(trackers); }
+
     /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
@@ -74,6 +87,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         setExpenses(newData.getExpenseList());
         setIncomes(newData.getIncomeList());
         setWishes(newData.getWishList());
+        setExpenseReminders(newData.getExpenseReminderList());
+        setExpenseTrackers(newData.getExpenseTrackerList());
     }
 
     //// person-level operations
@@ -121,6 +136,19 @@ public class AddressBook implements ReadOnlyAddressBook {
         wishes.add(wish);
     }
 
+    private void addExpenseTracker(ExpenseTracker tracker) {
+        expenseTrackers.add(tracker);
+    }
+
+    /**
+     * Adds the specified ExpenseTrackerReminder to the app.
+     * @param expenseReminder the specified ExpenseTracker to be added.
+     */
+    public void addExpenseReminder(ExpenseReminder expenseReminder) {
+        expenseReminders.add(expenseReminder);
+        addExpenseTracker(expenseReminder.getTracker());
+    }
+
     /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.
@@ -164,6 +192,23 @@ public class AddressBook implements ReadOnlyAddressBook {
         entries.setPerson(target, editedEntry);
     }
 
+    private void setExpenseTracker(ExpenseTracker target, ExpenseTracker editedEntry) {
+        requireNonNull(editedEntry);
+        expenseTrackers.setTracker(target, editedEntry);
+    }
+
+    /**
+     * Replaces the given ExpenseTracker {@code target} in the list with {@code editedTracker}.
+     * {@code target} must exist in the address book.
+     * The ExpenseTracer identity of {@code editedTracker}
+     * must not be the same as another existing ExpenseTracker in the address book.
+     */
+    public void setExpenseReminder(ExpenseReminder target, ExpenseReminder editedEntry) {
+        requireNonNull(editedEntry);
+        expenseReminders.setExpenseReminder(target, editedEntry);
+        setExpenseTracker(target.getTracker(), editedEntry.getTracker());
+    }
+
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
@@ -200,6 +245,25 @@ public class AddressBook implements ReadOnlyAddressBook {
         entries.remove(key);
     }
 
+
+
+    private void removeExpenseTracker(ExpenseTracker key) {
+        expenseTrackers.remove(key);
+    }
+
+    /**
+     * Removes {@code key} from this {@code wishes}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeExpenseReminder(ExpenseReminder key) {
+        expenseReminders.remove(key);
+        removeExpenseTracker(key.getTracker());
+    }
+
+    public void updateExpenseReminders() {
+        expenseReminders.updateList();
+    }
+
     //// util methods
 
     //// util methods
@@ -229,6 +293,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Wish> getWishList() {
         return wishes.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<ExpenseReminder> getExpenseReminderList() {
+        return expenseReminders.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<ExpenseTracker> getExpenseTrackerList() {
+        return expenseTrackers.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Entry;
 import seedu.address.model.person.Expense;
+import seedu.address.model.person.ExpenseReminder;
 import seedu.address.model.person.Income;
 import seedu.address.model.person.Wish;
 
@@ -90,24 +91,29 @@ public interface Model {
      */
     void deleteWish(Wish target);
 
+    void deleteExpenseReminder(ExpenseReminder target);
+
     /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */
     void addEntry(Entry entry);
 
-    public void addExpense(Expense expense);
+    void addExpense(Expense expense);
 
-    public void addIncome(Income income);
+    void addIncome(Income income);
 
-    public void addWish(Wish wish);
+    void addWish(Wish wish);
 
+    void addExpenseReminder(ExpenseReminder expenseReminder);
     /**
      * Replaces the given entry {@code target} with {@code editedEntry}.
      * {@code target} must exist in the address book.
      * The entry identity of {@code editedEntry} must not be the same as another existing entry in the address book.
      */
     void setEntry(Entry target, Entry editedEntry);
+
+    void setExpenseReminder(ExpenseReminder target, ExpenseReminder editedEntry);
 
     /** Returns an unmodifiable view of the filtered entry list */
     ObservableList<Entry> getFilteredEntryList();
@@ -121,6 +127,7 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered entry list */
     ObservableList<Wish> getFilteredWishes();
 
+    ObservableList<ExpenseReminder> getFilteredReminders();
     /**
      * Updates the filter of the filtered entry list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,8 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Entry;
 import seedu.address.model.person.Expense;
+import seedu.address.model.person.ExpenseReminder;
+import seedu.address.model.person.ExpenseTrackerManager;
 import seedu.address.model.person.Income;
 import seedu.address.model.person.Wish;
 
@@ -29,6 +31,8 @@ public class ModelManager implements Model {
     private final FilteredList<Expense> filteredExpenses;
     private final FilteredList<Income> filteredIncomes;
     private final FilteredList<Wish> filteredWishes;
+    private final FilteredList<ExpenseReminder> filteredExpenseReminders;
+    private final ExpenseTrackerManager expenseTrackers;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -45,6 +49,8 @@ public class ModelManager implements Model {
         filteredExpenses = new FilteredList<>(this.addressBook.getExpenseList());
         filteredIncomes = new FilteredList<>(this.addressBook.getIncomeList());
         filteredWishes = new FilteredList<>(this.addressBook.getWishList());
+        filteredExpenseReminders = new FilteredList<>(this.addressBook.getExpenseReminderList());
+        expenseTrackers = new ExpenseTrackerManager(this.addressBook.getExpenseTrackerList());
     }
 
     public ModelManager() {
@@ -104,11 +110,14 @@ public class ModelManager implements Model {
         return addressBook.hasEntry(entry);
     }
 
+
     @Override
     public void deleteEntry(Entry target) {
         addressBook.removeEntry(target);
         if (target instanceof Expense) {
             addressBook.removeExpense((Expense) target);
+            expenseTrackers.track(filteredExpenses);
+            addressBook.updateExpenseReminders();
         } else if (target instanceof Income) {
             addressBook.removeIncome((Income) target);
         } else if (target instanceof Wish) {
@@ -120,6 +129,8 @@ public class ModelManager implements Model {
     public void deleteExpense(Expense target) {
         addressBook.removeEntry(target);
         addressBook.removeExpense(target);
+        expenseTrackers.track(filteredExpenses);
+        addressBook.updateExpenseReminders();
     }
 
     @Override
@@ -135,10 +146,17 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteExpenseReminder(ExpenseReminder target) {
+        addressBook.removeExpenseReminder(target);
+    }
+
+    @Override
     public void addEntry(Entry entry) {
         addressBook.addEntry(entry);
         if (entry instanceof Expense) {
             addressBook.addExpense((Expense) entry);
+            expenseTrackers.track(filteredExpenses);
+            addressBook.updateExpenseReminders();
         } else if (entry instanceof Income) {
             addressBook.addIncome((Income) entry);
         } else if (entry instanceof Wish) {
@@ -151,6 +169,8 @@ public class ModelManager implements Model {
     public void addExpense(Expense expense) {
         addressBook.addExpense(expense);
         updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+        expenseTrackers.track(filteredExpenses);
+        addressBook.updateExpenseReminders();
     }
 
     @Override
@@ -166,16 +186,29 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addExpenseReminder(ExpenseReminder expenseReminder) {
+        addressBook.addExpenseReminder(expenseReminder);
+    }
+
+    @Override
     public void setEntry(Entry target, Entry editedEntry) {
         requireAllNonNull(target, editedEntry);
         addressBook.setEntry(target, editedEntry);
         if (target instanceof Expense) {
             addressBook.setExpense((Expense) target, (Expense) editedEntry);
+            expenseTrackers.track(filteredExpenses);
+            addressBook.updateExpenseReminders();
         } else if (target instanceof Income) {
             addressBook.setIncome((Income) target, (Income) editedEntry);
         } else if (target instanceof Wish) {
             addressBook.setWish((Wish) target, (Wish) editedEntry);
         }
+    }
+
+    @Override
+    public void setExpenseReminder(ExpenseReminder target, ExpenseReminder editedEntry) {
+        requireAllNonNull(target, editedEntry);
+        addressBook.setExpenseReminder(target, editedEntry);
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -202,6 +235,11 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Wish> getFilteredWishes() {
         return filteredWishes;
+    }
+
+    @Override
+    public ObservableList<ExpenseReminder> getFilteredReminders() {
+        return filteredExpenseReminders;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -3,6 +3,8 @@ package seedu.address.model;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Entry;
 import seedu.address.model.person.Expense;
+import seedu.address.model.person.ExpenseReminder;
+import seedu.address.model.person.ExpenseTracker;
 import seedu.address.model.person.Income;
 import seedu.address.model.person.Wish;
 
@@ -22,4 +24,8 @@ public interface ReadOnlyAddressBook {
     ObservableList<Income> getIncomeList();
 
     ObservableList<Wish> getWishList();
+
+    ObservableList<ExpenseReminder> getExpenseReminderList();
+
+    ObservableList<ExpenseTracker> getExpenseTrackerList();
 }

--- a/src/main/java/seedu/address/model/person/ExpenseContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/ExpenseContainsTagPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ */
+public class ExpenseContainsTagPredicate implements Predicate<Expense> {
+    private final Set<Tag> tags;
+
+    public ExpenseContainsTagPredicate(Set<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+    @Override
+    public boolean test(Expense entry) {
+        return tags.stream()
+                .anyMatch(tag -> entry.getTags().contains(tag));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExpenseContainsTagPredicate // instanceof handles nulls
+                && tags.equals(((ExpenseContainsTagPredicate) other).tags)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/ExpenseReminder.java
+++ b/src/main/java/seedu/address/model/person/ExpenseReminder.java
@@ -1,0 +1,58 @@
+package seedu.address.model.person;
+
+/**
+ * Implement expense tracker
+ */
+public class ExpenseReminder extends Reminder {
+    private long currSum;
+    private long quota;
+    private ExpenseTracker tracker;
+
+    public ExpenseReminder(String message, long quota, ExpenseTracker tracker) {
+        super(message);
+        this.tracker = tracker;
+        this.quota = quota;
+        currSum = tracker.getAmount();
+    }
+
+
+    public long getSum() {
+        return currSum;
+    }
+
+    public long getQuota() {
+        return quota;
+    }
+
+    public ExpenseTracker getTracker() {
+        return tracker;
+    }
+
+    /**
+     *checks status of reminder. i.e. should reminder trigger.
+     */
+    public void updateStatus() {
+        currSum = tracker.getAmount();
+        super.setStatus(currSum >= quota);
+    }
+
+    @Override
+    /**
+     * Returns true if both ExpenseReminders have all identity fields that are the same.
+     * @param otherExpenseReminder ExpenseReminder to compare to
+     * @return boolean
+     */
+    public boolean isSameReminder(Reminder otherReminder) {
+        if (otherReminder == this) {
+            return true;
+        }
+        if (!(otherReminder instanceof ExpenseReminder)) {
+            return false;
+        }
+        ExpenseReminder otherExpenseReminder = (ExpenseReminder) otherReminder;
+        return otherExpenseReminder != null
+                && otherExpenseReminder.getMessage().equals(getMessage())
+                && otherExpenseReminder.getTracker().equals(getTracker())
+                && otherExpenseReminder.getQuota() == (getQuota());
+    }
+}

--- a/src/main/java/seedu/address/model/person/ExpenseReminderList.java
+++ b/src/main/java/seedu/address/model/person/ExpenseReminderList.java
@@ -1,0 +1,147 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import seedu.address.model.person.exceptions.DuplicateEntryException;
+import seedu.address.model.person.exceptions.EntryNotFoundException;
+
+/**
+ * A list of persons that enforces uniqueness between its elements and does not allow nulls.
+ * A person is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
+ * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
+ * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
+ * as to ensure that the person with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ */
+public class ExpenseReminderList implements Iterable<ExpenseReminder> {
+
+    private final ObservableList<ExpenseReminder> internalList = FXCollections.observableArrayList();
+    private final ObservableList<ExpenseReminder> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent person as the given argument.
+     */
+    public boolean contains(ExpenseReminder toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameReminder);
+    }
+
+    /**
+     * Adds a person to the list.
+     * The person must not already exist in the list.
+     */
+    public void add(ExpenseReminder toAdd) {
+        requireNonNull(toAdd);
+
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the person {@code target} in the list with {@code editedPerson}.
+     * {@code target} must exist in the list.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the list.
+     */
+    public void setExpenseReminder(ExpenseReminder target, ExpenseReminder editedExpenseReminder) {
+        requireAllNonNull(target, editedExpenseReminder);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new EntryNotFoundException();
+        }
+
+        if (!target.equals(editedExpenseReminder) && contains(editedExpenseReminder)) {
+            throw new DuplicateEntryException();
+        }
+
+        internalList.set(index, editedExpenseReminder);
+    }
+
+    /**
+     * Removes the equivalent person from the list.
+     * The person must exist in the list.
+     */
+    public void remove(ExpenseReminder toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new EntryNotFoundException();
+        }
+    }
+
+    public void setEntries(ExpenseReminderList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code persons}.
+     * {@code persons} must not contain duplicate persons.
+     */
+    public void setEntries(List<ExpenseReminder> entries) {
+        requireAllNonNull(entries);
+
+        internalList.setAll(entries);
+    }
+
+    /**
+     * updates the status of all reminders in ExpenseReminderList
+     */
+    public void updateList() {
+        for (ExpenseReminder reminder : internalList) {
+            reminder.updateStatus();
+        }
+    }
+
+    /**
+     * Get list of reminders to be displayed on main page.
+     */
+    public ObservableList<ExpenseReminder> getDisplay() {
+        FilteredList<ExpenseReminder> displayList = new FilteredList<>(this.asUnmodifiableObservableList());
+        displayList.setPredicate(new ExpenseReminderIsActive());
+        return displayList;
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<ExpenseReminder> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<ExpenseReminder> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExpenseReminderList // instanceof handles nulls
+                && internalList.equals(((ExpenseReminderList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+}
+
+/**
+ * Predicate to filter reminders to be displayed.
+ */
+class ExpenseReminderIsActive implements Predicate<ExpenseReminder> {
+    @Override
+    public boolean test(ExpenseReminder entry) {
+        return entry.getStatus();
+    }
+}

--- a/src/main/java/seedu/address/model/person/ExpenseTracker.java
+++ b/src/main/java/seedu/address/model/person/ExpenseTracker.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person;
+
+
+/**
+ * Expense Tracker used by expense reminder to trigger reminder.
+ */
+public class ExpenseTracker {
+    private long currAmount;
+    private ExpenseContainsTagPredicate predicate;
+
+    public ExpenseTracker(ExpenseContainsTagPredicate predicate) {
+       this.predicate = predicate;
+        currAmount = 0;
+    }
+
+    public long getAmount() {
+        return currAmount;
+    }
+
+    public void setAmount(long newAmt) {
+        currAmount = newAmt;
+    }
+
+    public ExpenseContainsTagPredicate getPredicate() {
+        return predicate;
+    }
+
+    /**
+     * Used to compare if one tracker does the same thing as another.
+     * @param otherTracker tracker to compare with
+     * @return boolean value.
+     */
+    public boolean isSameEntry(ExpenseTracker otherTracker) {
+        if (otherTracker == this) {
+            return true;
+        }
+
+        return otherTracker != null
+                && otherTracker.getPredicate().equals(getPredicate());
+    }
+}

--- a/src/main/java/seedu/address/model/person/ExpenseTrackerList.java
+++ b/src/main/java/seedu/address/model/person/ExpenseTrackerList.java
@@ -1,0 +1,117 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.DuplicateEntryException;
+import seedu.address.model.person.exceptions.EntryNotFoundException;
+
+/**
+ * A list of persons that enforces uniqueness between its elements and does not allow nulls.
+ * A person is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
+ * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
+ * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
+ * as to ensure that the person with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ */
+public class ExpenseTrackerList implements Iterable<ExpenseTracker> {
+
+    private final ObservableList<ExpenseTracker> internalList = FXCollections.observableArrayList();
+
+    /**
+     * Returns true if the list contains an equivalent person as the given argument.
+     */
+    public boolean contains(ExpenseTracker toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameEntry);
+    }
+
+    /**
+     * Adds a person to the list.
+     * The person must not already exist in the list.
+     */
+    public void add(ExpenseTracker toAdd) {
+        requireNonNull(toAdd);
+
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the person {@code target} in the list with {@code editedPerson}.
+     * {@code target} must exist in the list.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the list.
+     */
+    public void setTracker(ExpenseTracker target, ExpenseTracker editedTracker) {
+        requireAllNonNull(target, editedTracker);
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new EntryNotFoundException();
+        }
+
+        if (!target.equals(editedTracker) && contains(editedTracker)) {
+            throw new DuplicateEntryException();
+        }
+
+        internalList.set(index, editedTracker);
+    }
+
+    /**
+     * Removes the equivalent person from the list.
+     * The person must exist in the list.
+     */
+    public void remove(ExpenseTracker toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new EntryNotFoundException();
+        }
+    }
+
+    public void setEntries(ExpenseTrackerList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+
+
+    /**
+     * Replaces the contents of this list with {@code persons}.
+     * {@code persons} must not contain duplicate persons.
+     */
+    public void setEntries(List<ExpenseTracker> entries) {
+        requireAllNonNull(entries);
+
+        internalList.setAll(entries);
+    }
+
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<ExpenseTracker> asUnmodifiableObservableList() {
+        return internalList;
+    }
+
+    @Override
+    public Iterator<ExpenseTracker> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExpenseTrackerList // instanceof handles nulls
+                && internalList.equals(((ExpenseTrackerList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/ExpenseTrackerManager.java
+++ b/src/main/java/seedu/address/model/person/ExpenseTrackerManager.java
@@ -1,0 +1,37 @@
+package seedu.address.model.person;
+
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+
+/**
+ * Manages ExpenseTrackerList. Will be instantiated inside Object Manager and Address Book.
+ */
+public class ExpenseTrackerManager {
+    private FilteredList<ExpenseTracker> trackerList;
+
+
+
+    public ExpenseTrackerManager(ObservableList<ExpenseTracker> trackerList) {
+        this.trackerList = new FilteredList<>(trackerList);
+    }
+
+
+    public ObservableList<ExpenseTracker> getList() {
+        return trackerList;
+    }
+
+    /**
+     * Iterates through list of trackers, and see which tracker(s) are keeping track of this event.
+     * @param filteredExpenses
+     */
+    public void track(FilteredList<Expense> filteredExpenses) {
+        for (ExpenseTracker tracker : trackerList) {
+            long newAmt = 0;
+            filteredExpenses.setPredicate(tracker.getPredicate());
+            for (Expense expense : filteredExpenses) {
+                newAmt += expense.getAmount().value;
+            }
+            tracker.setAmount(newAmt);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Reminder.java
+++ b/src/main/java/seedu/address/model/person/Reminder.java
@@ -1,0 +1,40 @@
+package seedu.address.model.person;
+
+/**
+ * Basic reminder class with minimal functionality.
+ */
+public abstract class Reminder {
+    private String message;
+    private boolean isActivated;
+    private int priority;
+
+
+    public Reminder(String message) {
+        this.message = message;
+        isActivated = false;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public boolean getStatus() {
+        return isActivated;
+    }
+
+    void setStatus(boolean bool) {
+        isActivated = bool;
+    }
+
+
+    @Override
+    public String toString() {
+        return "Reminder: " + message;
+    }
+
+    abstract boolean isSameReminder(Reminder reminder);
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedExpenseReminder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExpenseReminder.java
@@ -1,0 +1,79 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Description;
+import seedu.address.model.person.Entry;
+import seedu.address.model.person.ExpenseContainsTagPredicate;
+import seedu.address.model.person.ExpenseReminder;
+import seedu.address.model.person.ExpenseTracker;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Entry}.
+ */
+class JsonAdaptedExpenseReminder {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Expense's %s field is missing!";
+
+    private String message;
+    private long quota;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+
+    /**
+     * Constructs a {@code JsonAdaptedPerson} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedExpenseReminder(@JsonProperty("desc") String desc,
+                                      @JsonProperty("quota") long quota,
+                                      @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.message = desc;
+        this.quota = quota;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Person} into this class for Jackson use.
+     */
+    public JsonAdaptedExpenseReminder(ExpenseReminder source) {
+        message = source.getMessage();
+        quota = source.getQuota();
+        tagged.addAll(source.getTracker().getPredicate().getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public ExpenseReminder toModelType() throws IllegalValueException {
+        final List<Tag> entryTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            entryTags.add(tag.toModelType());
+        }
+        if (message == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Description.class.getSimpleName()));
+        }
+        final String modelMessage = message;
+        final long modelQuota = quota;
+        final Set<Tag> modelTags = new HashSet<>(entryTags);
+        final ExpenseContainsTagPredicate predicate = new ExpenseContainsTagPredicate(modelTags);
+        final ExpenseTracker tracker = new ExpenseTracker(predicate);
+        return new ExpenseReminder(modelMessage, modelQuota, tracker);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Expense;
+import seedu.address.model.person.ExpenseReminder;
 import seedu.address.model.person.Income;
 import seedu.address.model.person.Wish;
 /**
@@ -25,6 +26,7 @@ class JsonSerializableAddressBook {
     private final List<JsonAdaptedExpense> expenses = new ArrayList<>();
     private final List<JsonAdaptedIncome> incomes = new ArrayList<>();
     private final List<JsonAdaptedWish> wishes = new ArrayList<>();
+    private final List<JsonAdaptedExpenseReminder> expenseReminders = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
@@ -63,6 +65,10 @@ class JsonSerializableAddressBook {
         for (JsonAdaptedWish JsonAdaptedWish: wishes) {
             Wish wish = JsonAdaptedWish.toModelType();
             addressBook.addWish(wish);
+        }
+        for (JsonAdaptedExpenseReminder JsonAdaptedExpenseReminder : expenseReminders) {
+            ExpenseReminder reminder = JsonAdaptedExpenseReminder.toModelType();
+            addressBook.addExpenseReminder(reminder);
         }
         return addressBook;
     }


### PR DESCRIPTION
WIP Don't Merge

v0.01
- Implemented predicates activation condition for reminders
- implemented expenditure tracker
-implemented basic expenditure reminder. (Activates when expenditure exceeds stated amount for expenditure containing specified tags)
-implemented storage.

TODO:
- Find a way to display Reminders

- Add edit, delete and list Reminders (should be done soon)

- Implement basic WishList reminder.

- Find a way to store Predicate in JSON, and not construct them in the toModel method in 

- JSONAdaptedExpenseReminder

- Implementing command/parser that can handle multiple reminder types.

-rename methods/ classess. e.g. change "AddExpenseReminderCommand" to "AddReminderCommand"